### PR TITLE
The folder's name feature with RegExp for report

### DIFF
--- a/plugin/command.js
+++ b/plugin/command.js
@@ -22,11 +22,14 @@ function getSpecRelativePath() {
     Cypress.env("INTEGRATION_FOLDER"),
     path.join("cypress", "e2e")
   );
+  const testTitle = sanitize(Cypress.currentTest.title);
+  const regexp = new RegExp(Cypress.config().reporterOptions.cypressLensReporterOptions.titlePattern, "g");
+  const title = testTitle.match(regexp)[0] || testTitle.split(" ").join("-");
 
   return (
     Cypress.spec.relative.replace(integrationFolder, "") +
     "/" +
-    sanitize(Cypress.currentTest.title).split(" ").join("-")
+    title
   );
 }
 

--- a/plugin/command.js
+++ b/plugin/command.js
@@ -23,14 +23,11 @@ function getSpecRelativePath() {
     path.join("cypress", "e2e")
   );
   const testTitle = sanitize(Cypress.currentTest.title);
+  const titlePattern =
+    Cypress.config().reporterOptions.cypressLensReporterOptions.titlePattern;
   let title;
-  if (
-    Cypress.config().reporterOptions.cypressLensReporterOptions.titlePattern
-  ) {
-    const regexp = new RegExp(
-      Cypress.config().reporterOptions.cypressLensReporterOptions.titlePattern,
-      "g"
-    );
+  if (titlePattern) {
+    const regexp = new RegExp(titlePattern, "g");
     title = testTitle.match(regexp)[0];
   } else {
     title = testTitle.split(" ").join("-");

--- a/plugin/command.js
+++ b/plugin/command.js
@@ -23,14 +23,20 @@ function getSpecRelativePath() {
     path.join("cypress", "e2e")
   );
   const testTitle = sanitize(Cypress.currentTest.title);
-  const regexp = new RegExp(Cypress.config().reporterOptions.cypressLensReporterOptions.titlePattern, "g");
-  const title = testTitle.match(regexp)[0] || testTitle.split(" ").join("-");
+  let title;
+  if (
+    Cypress.config().reporterOptions.cypressLensReporterOptions.titlePattern
+  ) {
+    const regexp = new RegExp(
+      Cypress.config().reporterOptions.cypressLensReporterOptions.titlePattern,
+      "g"
+    );
+    title = testTitle.match(regexp)[0];
+  } else {
+    title = testTitle.split(" ").join("-");
+  }
 
-  return (
-    Cypress.spec.relative.replace(integrationFolder, "") +
-    "/" +
-    title
-  );
+  return Cypress.spec.relative.replace(integrationFolder, "") + "/" + title;
 }
 
 /** Take a screenshot and move screenshot to base or actual folder */

--- a/reporter/index.js
+++ b/reporter/index.js
@@ -84,8 +84,9 @@ Reporter.prototype.getTestsuiteData = function (suite) {
 Reporter.prototype.getSnapshotsData = function (test) {
   const testTitle = sanitize(test.title);
   let pathTitle;
-  if (this._options.reporterOptions.titlePattern) {
-    const regexp = new RegExp(this._options.reporterOptions.titlePattern, "g");
+  const titlePattern = this._options.reporterOptions.titlePattern;
+  if (titlePattern) {
+    const regexp = new RegExp(titlePattern, "g");
     pathTitle = testTitle.match(regexp)[0];
   } else {
     pathTitle = sanitize(test.title).split(" ").join("-");

--- a/reporter/index.js
+++ b/reporter/index.js
@@ -83,9 +83,13 @@ Reporter.prototype.getTestsuiteData = function (suite) {
 
 Reporter.prototype.getSnapshotsData = function (test) {
   const testTitle = sanitize(test.title);
-  const regexp = new RegExp(this._options.reporterOptions.titlePattern, "g");
-  const pathTitle =
-    testTitle.match(regexp)[0] || sanitize(test.title).split(" ").join("-");
+  let pathTitle;
+  if (this._options.reporterOptions.titlePattern) {
+    const regexp = new RegExp(this._options.reporterOptions.titlePattern, "g");
+    pathTitle = testTitle.match(regexp)[0];
+  } else {
+    pathTitle = sanitize(test.title).split(" ").join("-");
+  }
 
   let snapshots = [];
   const testPath =

--- a/reporter/index.js
+++ b/reporter/index.js
@@ -82,13 +82,16 @@ Reporter.prototype.getTestsuiteData = function (suite) {
 };
 
 Reporter.prototype.getSnapshotsData = function (test) {
-  const title = sanitize(test.title).split(" ").join("-");
+  const testTitle = sanitize(test.title);
+  const regexp = new RegExp(this._options.reporterOptions.titlePattern, "g");
+  const pathTitle =
+    testTitle.match(regexp)[0] || sanitize(test.title).split(" ").join("-");
 
   let snapshots = [];
   const testPath =
     test.invocationDetails.fileUrl.split("p=")[1].replace(/\\/g, "/") +
     "/" +
-    title;
+    pathTitle;
   let basePath = path.resolve(`./cypress/snapshots/base/${testPath}`);
 
   fs.existsSync(basePath) &&


### PR DESCRIPTION
This feature provides a configuration for your folder's name modifications in the report which is supported by cypress-multi-reporter in **cypress.config.ts**, you need to add the reporterOptions object into the e2e configuration:
`cypress.config.ts`
![image](https://github.com/dreamshotrocks/cypress-lens/assets/143711078/d6f52aa3-96ea-4356-9544-124fdddb069b)

`cypress.config.ts`
```
    reporterOptions: {
      reporterEnabled: "spec, cypress-lens",
      cypressLensReporterOptions: {
        // titlePattern: "(?<=\\[).*(?=\\])",
      },
    },
```
In this titlePattern example, you can extract the text between the [ ] 
Actual result in folder's name:  snapshots/base/**[Test-13] Does display the main page**
Expect the result in the folder's name: snapshots/base/**Test-13**