### PR TITLE
Change build output settings in Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,15 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
-  base: "/",
+  base: "",
   plugins: [react()],
+  build: {
+    outDir: "build/",
+    rollupOptions: {
+      output: {
+        entryFileNames: "static/js/main.js",
+        assetFileNames: "static/css/main.css",
+      },
+    },
+  },
 });


### PR DESCRIPTION
# Fix Vite Output Settings for Report HTML

## Overview

This pull request addresses an issue where the Vite output settings did not correspond to the generated Report HTML `<script>` tags.

## Changes

- Updated Vite configuration to ensure the output settings match the requirements of the generated Report HTML.
