### PR TITLE
refactor: update Cypress configuration to use `Cypress.expose()` instead of `Cypress.env()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,18 @@ it("Should display the home page according to baseline snapshot", () => {
 
 ```js
 {
-  env: {
+  expose: {
     failSilently: false;
   }
 }
 ```
+
+> **Note:** As of `cypress-lens` 2.0, configuration is read through Cypress'
+> `Cypress.expose()` API (introduced in Cypress 15.10.0) instead of the
+> deprecated `Cypress.env()`. Put cypress-lens settings such as `type`,
+> `SNAPSHOT_BASE_DIRECTORY`, `SNAPSHOT_DIFF_DIRECTORY`, `ALWAYS_GENERATE_DIFF`,
+> `ALLOW_VISUAL_REGRESSION_TO_FAIL` and `INTEGRATION_FOLDER` under the `expose`
+> config key (or pass them via the `--expose` CLI flag) rather than `env`.
 
 You can also pass default arguments to `compareSnapshotCommand()`:
 
@@ -183,11 +190,11 @@ These will be used by default when no parameters are passed to the compareSnapsh
 ### Take the base images:
 
 ```sh
-$ ./node_modules/.bin/cypress run --env type=base"
+$ ./node_modules/.bin/cypress run --expose type=base
 ```
 
 ### Find regressions:
 
 ```sh
-$ ./node_modules/.bin/cypress run --env type=actual
+$ ./node_modules/.bin/cypress run --expose type=actual
 ```

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   ],
   "main": "./reporter/index.js",
   "scripts": {
-    "test": "cypress run --env type=actual",
-    "base": "cypress run --env type=base",
+    "test": "cypress run --expose type=actual",
+    "base": "cypress run --expose type=base",
     "prepublish": "npm run build",
     "lint": "eslint plugin",
     "prebuild": "rimraf dist",
@@ -47,7 +47,7 @@
     "vite": "^5.3.1"
   },
   "peerDependencies": {
-    "cypress": ">=9.7.0"
+    "cypress": ">=15.10.0"
   },
   "files": [
     "dist/**/*",

--- a/plugin/command.js
+++ b/plugin/command.js
@@ -19,7 +19,7 @@ function getErrorThreshold(defaultScreenshotOptions, params) {
 
 function getSpecRelativePath() {
   const integrationFolder = getValueOrDefault(
-    Cypress.env("INTEGRATION_FOLDER"),
+    Cypress.expose("INTEGRATION_FOLDER"),
     path.join("cypress", "e2e")
   );
   const testTitle = sanitize(Cypress.currentTest.title);
@@ -69,7 +69,7 @@ function updateScreenshot(name) {
     name,
     specDirectory: getSpecRelativePath(),
     screenshotsFolder: Cypress.config().screenshotsFolder,
-    snapshotBaseDirectory: Cypress.env("SNAPSHOT_BASE_DIRECTORY"),
+    snapshotBaseDirectory: Cypress.expose("SNAPSHOT_BASE_DIRECTORY"),
   });
 }
 
@@ -78,19 +78,21 @@ function compareScreenshots(name, errorThreshold) {
   const options = {
     fileName: name,
     specDirectory: getSpecRelativePath(),
-    baseDir: Cypress.env("SNAPSHOT_BASE_DIRECTORY"),
-    diffDir: Cypress.env("SNAPSHOT_DIFF_DIRECTORY"),
-    keepDiff: Cypress.env("ALWAYS_GENERATE_DIFF"),
-    allowVisualRegressionToFail: Cypress.env("ALLOW_VISUAL_REGRESSION_TO_FAIL"),
+    baseDir: Cypress.expose("SNAPSHOT_BASE_DIRECTORY"),
+    diffDir: Cypress.expose("SNAPSHOT_DIFF_DIRECTORY"),
+    keepDiff: Cypress.expose("ALWAYS_GENERATE_DIFF"),
+    allowVisualRegressionToFail: Cypress.expose(
+      "ALLOW_VISUAL_REGRESSION_TO_FAIL"
+    ),
     errorThreshold,
   };
 
   cy.task("compareSnapshotsPlugin", options).then((results) => {
     if (results.error) {
-      const collectVisualErros = Cypress.env().collectVisualErros;
+      const collectVisualErros = Cypress.expose("collectVisualErros");
 
       if (collectVisualErros) {
-        const visualErrors = Cypress.env().visualErrors || [];
+        const visualErrors = Cypress.expose("visualErrors") || [];
         if (visualErrors) {
           let errorMessage = {
             message: "Failed to parse json in cypress-lens",
@@ -116,7 +118,7 @@ function compareSnapshotCommand(defaultScreenshotOptions) {
     "compareSnapshot",
     { prevSubject: "optional" },
     (subject, name, params = {}) => {
-      const type = Cypress.env("type");
+      const type = Cypress.expose("type");
       const screenshotOptions =
         typeof params === "object"
           ? { ...defaultScreenshotOptions, ...params }

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -17,7 +17,9 @@ const { getValueOrDefault } = require("./utils-browser");
 let CYPRESS_SCREENSHOT_DIR;
 
 function setupScreenshotPath(config) {
-  config.env.type === "actual"
+  const type = config?.expose?.type;
+
+  type === "actual"
     ? (CYPRESS_SCREENSHOT_DIR = "cypress/snapshots/actual")
     : (CYPRESS_SCREENSHOT_DIR = getValueOrDefault(
         config?.screenshotsFolder,

--- a/test.sh
+++ b/test.sh
@@ -19,6 +19,6 @@ else
 fi
 
 docker run -d --name cypress-test cypress-visual-regression sleep infinity
-docker exec cypress-test bash -c './node_modules/.bin/cypress run --env type=base'
-docker exec cypress-test bash -c './node_modules/.bin/cypress run --env type=actual'
+docker exec cypress-test bash -c './node_modules/.bin/cypress run --expose type=base'
+docker exec cypress-test bash -c './node_modules/.bin/cypress run --expose type=actual'
 docker rm -f cypress-test

--- a/tests/command.spec.js
+++ b/tests/command.spec.js
@@ -1,5 +1,6 @@
 global.Cypress = {
   env: () => false,
+  expose: () => false,
   log: () => null,
   config: () => '/cypress/screenshots',
   Commands: {


### PR DESCRIPTION
- Changed script commands in package.json to use `--expose` flag.
- Updated README to reflect new configuration method.
- Modified plugin and command files to access configuration via `Cypress.expose()`.
- Adjusted test script to align with new command structure.